### PR TITLE
feat: Add bs/be baseline range parameters with auto PI for post-baseline

### DIFF
--- a/docs/baseline-zscore-spec.md
+++ b/docs/baseline-zscore-spec.md
@@ -1,0 +1,159 @@
+# Baseline Z-Score API Specification
+
+## Overview
+
+This spec describes changes to the stats API to support z-score calculation for all observed data periods, including pre-baseline, baseline, and post-baseline periods.
+
+## Current Behavior
+
+**Parameters:**
+- `y` = observed data (typically just baseline values)
+- `b` = baseline length (baseline = `y[1:b]`)
+- `h` = forecast horizon
+
+**Issues:**
+1. Frontend only sends baseline data in `y`, not full observed series
+2. Z-scores only calculated for data in `y`
+3. Forecast period z-scores set to `0` instead of `NA`
+4. No support for pre-baseline z-scores
+
+## Proposed Changes
+
+### New Parameter: `bs` (baseline start)
+
+Add optional `bs` parameter to specify where baseline period begins.
+
+**Parameters:**
+- `y` = ALL observed data (pre-baseline + baseline + post-baseline)
+- `bs` = baseline start index (1-indexed, optional)
+- `be` = baseline end index (1-indexed, optional, replaces `b` when `bs` is used)
+- `b` = baseline length (kept for backwards compatibility)
+- `h` = forecast horizon
+
+### Backwards Compatibility
+
+| Request | Baseline Period |
+|---------|-----------------|
+| `y=...&b=5&h=3` | `y[1:5]` (current behavior) |
+| `y=...&bs=3&be=5&h=3` | `y[3:5]` (new behavior) |
+
+When only `b` is provided (no `bs`), behavior is unchanged: baseline = `y[1:b]`.
+
+### Example
+
+**Scenario:** User has data for 2015-2024 (10 years), wants baseline 2017-2019.
+
+```
+GET /?y=100,105,110,115,120,150,180,160,140,130&bs=3&be=5&h=3&s=1&t=0&m=mean
+```
+
+- `y[1:2]` = 2015-2016 (pre-baseline observed)
+- `y[3:5]` = 2017-2019 (baseline period, model fitted here)
+- `y[6:10]` = 2020-2024 (post-baseline observed)
+- `h=3` = 2025-2027 (forecast, no observed data)
+
+**Response:**
+```json
+{
+  "y": [108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3, 108.3],
+  "lower": [null, null, null, null, null, null, null, null, null, null, 95.2, 95.2, 95.2],
+  "upper": [null, null, null, null, null, null, null, null, null, null, 121.4, 121.4, 121.4],
+  "zscore": [-1.66, -0.66, 0.34, 1.34, 2.34, 8.34, 14.34, 10.34, 6.34, 4.34, null, null, null]
+}
+```
+
+**Output lengths:** `length(y) + h` = 10 + 3 = 13 values
+
+### Z-Score Calculation by Period
+
+| Period | Z-Score Formula | Notes |
+|--------|-----------------|-------|
+| Pre-baseline | `(observed - predicted) / baseline_sd` | Model extrapolates backwards via `new_data` |
+| Baseline | `(observed - fitted) / baseline_sd` | Standard residuals from model fit |
+| Post-baseline | `(observed - predicted) / baseline_sd` | Model forecasts forward |
+| Forecast | `NA` | No observed data to compare |
+
+Where:
+- `baseline_sd` = standard deviation of baseline residuals
+- `predicted` = model prediction for that time point
+- `fitted` = model fitted value (only available for baseline period)
+
+### Validation Rules
+
+1. `bs` must be >= 1
+2. `be` must be > `bs`
+3. `be` must be <= `length(y)`
+4. Baseline period (`y[bs:be]`) must have at least 3 non-NA values
+5. If `bs` is provided, `be` must also be provided (and `b` is ignored)
+6. If only `b` is provided, `bs` defaults to 1 and `be` defaults to `b`
+
+### Implementation Notes
+
+#### R/fable approach
+
+```r
+# Fit model on baseline only
+df_baseline <- df |> filter(index >= bs & index <= be)
+mdl <- df_baseline |> model(...)
+
+# Get fitted values for baseline
+baseline_fitted <- mdl |> augment()
+
+# Predict pre-baseline using new_data
+if (bs > 1) {
+  pre_baseline_df <- df |> filter(index < bs)
+  pre_baseline_pred <- mdl |> forecast(new_data = pre_baseline_df)
+}
+
+# Predict post-baseline + forecast using forecast(h=...)
+post_baseline_h <- length(y) - be + h
+post_pred <- mdl |> forecast(h = post_baseline_h)
+
+# Calculate z-scores
+baseline_residuals <- observed[bs:be] - fitted[bs:be]
+baseline_sd <- sd(baseline_residuals)
+
+# Pre-baseline z-scores
+zscore[1:(bs-1)] <- (observed[1:(bs-1)] - pre_baseline_pred) / baseline_sd
+
+# Baseline z-scores
+zscore[bs:be] <- baseline_residuals / baseline_sd
+
+# Post-baseline z-scores
+zscore[(be+1):length(y)] <- (observed[(be+1):length(y)] - post_pred[1:n_post]) / baseline_sd
+
+# Forecast z-scores
+zscore[(length(y)+1):(length(y)+h)] <- NA
+```
+
+### Response Structure
+
+No changes to response structure, just semantics:
+
+```json
+{
+  "y": [...],      // length = length(input_y) + h
+  "lower": [...],  // length = length(input_y) + h, NA for non-forecast periods
+  "upper": [...],  // length = length(input_y) + h, NA for non-forecast periods
+  "zscore": [...]  // length = length(input_y) + h, NA for forecast periods
+}
+```
+
+### Frontend Changes Required
+
+1. Send ALL observed data in `y`, not just baseline
+2. Add `bs` and `be` parameters based on user's baseline selection
+3. Handle `null`/`NA` z-scores for forecast periods (display as empty or N/A)
+
+### Benefits
+
+1. **Complete z-scores**: Z-scores calculated for all observed periods, not just baseline
+2. **Consistent data**: FE always sends full dataset, response always covers full range
+3. **No alignment issues**: Response indices directly map to input indices
+4. **Simpler visibility changes**: When user adjusts chart visibility (not baseline), no re-request needed since all data is already available
+
+### Migration Path
+
+1. Deploy backend with `bs`/`be` support (backwards compatible)
+2. Update frontend to send full data with `bs`/`be`
+3. Old frontend requests continue to work with `b` parameter

--- a/src/handlers.r
+++ b/src/handlers.r
@@ -38,30 +38,68 @@ if (!file.exists(median_model_path)) {
 
 source(median_model_path)
 
-#' Calculate z-scores for baseline and post-baseline periods
+#' Calculate z-scores for all periods (pre-baseline, baseline, post-baseline, forecast)
 #'
-#' @param y_full Full dataset including both baseline and post-baseline
-#' @param baseline_length Length of baseline period
+#' @param y_full Full dataset including all observed data
+#' @param bs Baseline start index (1-indexed)
+#' @param be Baseline end index (1-indexed)
 #' @param baseline_residuals Residuals from baseline model fit
 #' @param mdl Fitted model object
 #' @param result_length Total length of result vector (includes forecast)
-#' @param leading_NA Number of leading NA values
 #' @param h Forecast horizon
+#' @param df_baseline Baseline tsibble (for generating pre-baseline predictions)
 #' @return Vector of z-scores
-calculate_zscores <- function(y_full, baseline_length, baseline_residuals,
-                               mdl, result_length, leading_NA, h) {
+calculate_zscores <- function(y_full, bs, be, baseline_residuals,
+                               mdl, result_length, h, df_baseline) {
   residual_sd <- sd(baseline_residuals, na.rm = TRUE)
   zscores <- rep(NA, result_length)
 
+  # Pre-baseline z-scores (if bs > 1)
+  if (bs > 1) {
+    pre_baseline_data <- y_full[1:(bs - 1)]
+    pre_baseline_non_na_idx <- which(!is.na(pre_baseline_data))
+    pre_baseline_clean <- pre_baseline_data[pre_baseline_non_na_idx]
+
+    if (length(pre_baseline_clean) > 0) {
+      # Create new_data for pre-baseline period by going backwards from baseline start
+      # We need to forecast "backwards" using new_data
+      first_baseline_idx <- df_baseline$year[1]
+
+      # Create pre-baseline time indices
+      if (inherits(first_baseline_idx, "yearquarter")) {
+        pre_indices <- first_baseline_idx - (bs - 1):1
+      } else if (inherits(first_baseline_idx, "yearmonth")) {
+        pre_indices <- first_baseline_idx - (bs - 1):1
+      } else if (inherits(first_baseline_idx, "yearweek")) {
+        pre_indices <- first_baseline_idx - (bs - 1):1
+      } else {
+        # Annual/integer index
+        pre_indices <- (first_baseline_idx - (bs - 1)):(first_baseline_idx - 1)
+      }
+
+      pre_baseline_df <- tibble(year = pre_indices, asmr = pre_baseline_data) |>
+        as_tsibble(index = year)
+
+      # Use forecast with new_data to get predictions for pre-baseline
+      pre_baseline_pred <- mdl |> forecast(new_data = pre_baseline_df)
+      pre_baseline_fitted <- as_tibble(pre_baseline_pred) |> pull(.mean)
+
+      # Calculate z-scores for pre-baseline (only non-NA positions)
+      pre_baseline_residuals <- pre_baseline_clean - pre_baseline_fitted[pre_baseline_non_na_idx]
+      pre_baseline_zscores <- pre_baseline_residuals / residual_sd
+
+      zscores[pre_baseline_non_na_idx] <- round(pre_baseline_zscores, 3)
+    }
+  }
+
   # Baseline period z-scores (from model residuals)
   n_baseline_values <- length(baseline_residuals)
-  zscores[(leading_NA + 1):(leading_NA + n_baseline_values)] <-
+  zscores[bs:(bs + n_baseline_values - 1)] <-
     round(baseline_residuals / residual_sd, 3)
 
   # Post-baseline observed data z-scores
-  n_post_baseline_total <- 0
-  if (baseline_length < length(y_full)) {
-    post_baseline_data <- y_full[(baseline_length + 1):length(y_full)]
+  if (be < length(y_full)) {
+    post_baseline_data <- y_full[(be + 1):length(y_full)]
     n_post_baseline_total <- length(post_baseline_data)
 
     # Track which positions have non-NA values for correct z-score alignment
@@ -77,16 +115,14 @@ calculate_zscores <- function(y_full, baseline_length, baseline_residuals,
       post_baseline_residuals <- post_baseline_clean - post_baseline_fitted
       post_baseline_zscores <- post_baseline_residuals / residual_sd
 
-      # Assign z-scores to correct positions (vectorized)
-      post_baseline_start <- leading_NA + n_baseline_values
-      zscore_indices <- post_baseline_start + post_baseline_non_na_idx
+      # Assign z-scores to correct positions
+      zscore_indices <- be + post_baseline_non_na_idx
       zscores[zscore_indices] <- round(post_baseline_zscores, 3)
     }
   }
 
-  # Forecast period z-scores are 0 (by definition)
-  forecast_start <- leading_NA + n_baseline_values + n_post_baseline_total + 1
-  zscores[forecast_start:length(zscores)] <- rep(0, h)
+  # Forecast period z-scores are NA (no observed data to compare)
+  # They are already NA from initialization, no need to set them
 
   zscores
 }
@@ -100,142 +136,182 @@ calculate_zscores <- function(y_full, baseline_length, baseline_residuals,
 #' @param m Character method: "naive", "mean", "lin_reg", "exp", "median"
 #' @param s Integer seasonality type: 1=year, 2=quarter, 3=month, 4=week
 #' @param t Boolean whether to include trend
-#' @param baseline_length Integer number of data points in baseline period (default: use all data)
+#' @param bs Baseline start index (1-indexed, optional). If NULL, defaults to 1.
+#' @param be Baseline end index (1-indexed, optional). If NULL, defaults to length(y).
 #'
 #' @details
 #' Z-score Calculation:
-#' When baseline_length is specified, z-scores measure how much each observation
-#' deviates from what the baseline model predicts:
-#' - Baseline period: z = (observed - baseline_fitted) / baseline_sd
-#' - Post-baseline period: z = (observed - post_baseline_fitted) / baseline_sd
-#'   where post_baseline_fitted is the baseline model's prediction for that timepoint
-#' - Forecast period: z = 0 (by definition, no observed deviation)
+#' Z-scores measure how much each observation deviates from what the baseline model predicts:
+#' - Pre-baseline period: z = (observed - predicted) / baseline_sd (model extrapolates backwards)
+#' - Baseline period: z = (observed - fitted) / baseline_sd (standard residuals)
+#' - Post-baseline period: z = (observed - predicted) / baseline_sd (model forecasts forward)
+#' - Forecast period: z = NA (no observed data to compare)
 #'
-#' This means post-baseline z-scores measure deviation from the baseline model's
-#' prediction, NOT from the baseline period's mean. A high z-score in the post-baseline
-#' period indicates the observed value differs significantly from what the baseline
-#' model would have predicted.
+#' This means z-scores measure deviation from the baseline model's prediction,
+#' NOT from the baseline period's mean. A high z-score indicates the observed
+#' value differs significantly from what the baseline model would have predicted.
 #'
 #' @return List with y (fitted + forecast), lower, and upper bounds, and zscore
-handleForecast <- function(y, h, m, s, t, baseline_length = NULL) {
-  # If baseline_length is specified, split the data
-  # Use first baseline_length points for fitting, but calculate z-scores for all observed data
+handleForecast <- function(y, h, m, s, t, bs = NULL, be = NULL) {
   y_full <- y
-  if (!is.null(baseline_length) && baseline_length > 0 && baseline_length < length(y)) {
-    y_baseline <- y[1:baseline_length]
-  } else {
-    y_baseline <- y
-    baseline_length <- length(y)
-  }
 
-  df <- tibble(year = seq.int(1, length(y_baseline)), asmr = y_baseline)
+  # Set defaults for baseline start/end if not provided
+  if (is.null(bs)) bs <- 1L
+  if (is.null(be)) be <- length(y)
+
+  # Extract baseline data
+  y_baseline <- y[bs:be]
+
+  # Count leading NAs in the full input (for output alignment)
+  # Leading NAs are NA values before the first non-NA value in the input
+  first_non_na_idx <- which(!is.na(y))[1]
+  leading_NA <- if (is.na(first_non_na_idx)) 0 else first_non_na_idx - 1
+
+  # Create time series index starting from baseline start
+  # Adjust for leading NAs when bs=1 (backwards compatible behavior)
+  actual_bs <- if (bs == 1 && leading_NA > 0) leading_NA + 1 else bs
+  y_baseline_clean <- if (bs == 1 && leading_NA > 0) y[(leading_NA + 1):be] else y_baseline
+
+  df_baseline <- tibble(year = seq.int(actual_bs, be), asmr = y_baseline_clean)
 
   # Convert to appropriate time series index based on seasonality
   if (s == 2) {
-    df$year <- make_yearquarter(2000, 1) + 0:(length(y_baseline) - 1)
+    df_baseline$year <- make_yearquarter(2000, 1) + 0:(length(y_baseline_clean) - 1)
   } else if (s == 3) {
-    df$year <- make_yearmonth(2000, 1) + 0:(length(y_baseline) - 1)
+    df_baseline$year <- make_yearmonth(2000, 1) + 0:(length(y_baseline_clean) - 1)
   } else if (s == 4) {
-    df$year <- make_yearweek(2000, 1) + 0:(length(y_baseline) - 1)
+    df_baseline$year <- make_yearweek(2000, 1) + 0:(length(y_baseline_clean) - 1)
   }
 
-  # Count leading NAs
-  leading_NA <- nrow(df |> filter(is.na(asmr)))
-
-  # Convert to tsibble and remove NAs
-  df <- df |>
+  # Convert to tsibble and remove any remaining interspersed NAs
+  df_baseline <- df_baseline |>
     as_tsibble(index = year) |>
     filter(!is.na(asmr))
 
   # Fit model based on method
   if (m == "naive") {
-    mdl <- df |> model(NAIVE(asmr))
+    mdl <- df_baseline |> model(NAIVE(asmr))
   } else if (m == "mean") {
     if (s > 1) {
-      mdl <- df |> model(TSLM(asmr ~ season()))
+      mdl <- df_baseline |> model(TSLM(asmr ~ season()))
     } else {
-      mdl <- df |> model(TSLM(asmr))
+      mdl <- df_baseline |> model(TSLM(asmr))
     }
   } else if (m == "median") {
     if (s > 1) {
-      mdl <- df |> model(MEDIAN(asmr ~ season()))
+      mdl <- df_baseline |> model(MEDIAN(asmr ~ season()))
     } else {
-      mdl <- df |> model(MEDIAN(asmr))
+      mdl <- df_baseline |> model(MEDIAN(asmr))
     }
   } else if (m == "lin_reg") {
     if (t) {
       if (s > 1) {
-        mdl <- df |> model(TSLM(asmr ~ trend() + season()))
+        mdl <- df_baseline |> model(TSLM(asmr ~ trend() + season()))
       } else {
-        mdl <- df |> model(TSLM(asmr ~ trend()))
+        mdl <- df_baseline |> model(TSLM(asmr ~ trend()))
       }
     } else {
       if (s > 1) {
-        mdl <- df |> model(TSLM(asmr ~ season()))
+        mdl <- df_baseline |> model(TSLM(asmr ~ season()))
       } else {
-        mdl <- df |> model(TSLM(asmr))
+        mdl <- df_baseline |> model(TSLM(asmr))
       }
     }
   } else if (m == "exp") {
     if (s > 1) {
-      mdl <- df |> model(ETS(asmr ~ error() + trend() + season()))
+      mdl <- df_baseline |> model(ETS(asmr ~ error() + trend() + season()))
     } else {
-      mdl <- df |> model(ETS(asmr ~ error("A") + trend("Ad")))
+      mdl <- df_baseline |> model(ETS(asmr ~ error("A") + trend("Ad")))
     }
   } else {
     stop(paste("Unknown method:", m))
   }
-
-  # Generate forecast
-  fc <- mdl |> forecast(h = h)
 
   # Get baseline (fitted values)
   bl <- mdl |>
     augment() |>
     rename(.mean = .fitted)
 
-  # Extract forecast with confidence intervals
-  result <- fabletools::hilo(fc, 95) |>
-    unpack_hilo(cols = `95%`) |>
-    as_tibble() |>
-    select(.mean, "95%_lower", "95%_upper") |>
-    setNames(c("y", "lower", "upper"))
+  # Calculate predictions for all periods
+  # Account for leading NAs when bs=1
+  n_pre_baseline <- if (bs == 1 && leading_NA > 0) 0 else (bs - 1)
+  n_post_baseline <- length(y_full) - be
 
-  # Get post-baseline period length
-  n_post_baseline <- if (baseline_length < length(y_full)) {
-    length(y_full) - baseline_length
+  # Generate predictions for pre-baseline period (if any) - no PI
+  pre_baseline_result <- if (n_pre_baseline > 0) {
+    first_baseline_idx <- df_baseline$year[1]
+    # Create pre-baseline time indices
+    if (inherits(first_baseline_idx, "yearquarter")) {
+      pre_indices <- first_baseline_idx - n_pre_baseline:1
+    } else if (inherits(first_baseline_idx, "yearmonth")) {
+      pre_indices <- first_baseline_idx - n_pre_baseline:1
+    } else if (inherits(first_baseline_idx, "yearweek")) {
+      pre_indices <- first_baseline_idx - n_pre_baseline:1
+    } else {
+      pre_indices <- (first_baseline_idx - n_pre_baseline):(first_baseline_idx - 1)
+    }
+    pre_df <- tibble(year = pre_indices, asmr = y_full[1:n_pre_baseline]) |>
+      as_tsibble(index = year)
+    fc_pre <- mdl |> forecast(new_data = pre_df)
+    tibble(y = as_tibble(fc_pre) |> pull(.mean), lower = NA, upper = NA)
   } else {
-    0
+    tibble(y = numeric(0), lower = numeric(0), upper = numeric(0))
   }
 
-  # Generate baseline predictions for post-baseline period
-  # (what the baseline model predicts, not observed values)
-  post_baseline_predicted <- if (n_post_baseline > 0) {
+  # Generate predictions for post-baseline period with PI (this is the "forecast" region)
+  # When bs/be are explicitly provided, post-baseline gets PI
+  # h is only used for extending beyond observed data (legacy mode or explicit extension)
+  post_baseline_result <- if (n_post_baseline > 0) {
     fc_post <- mdl |> forecast(h = n_post_baseline)
-    as_tibble(fc_post) |> pull(.mean)
+    fc_post_hilo <- fabletools::hilo(fc_post, 95) |>
+      unpack_hilo(cols = `95%`) |>
+      as_tibble() |>
+      select(.mean, "95%_lower", "95%_upper") |>
+      setNames(c("y", "lower", "upper"))
+    fc_post_hilo
   } else {
-    numeric(0)
+    tibble(y = numeric(0), lower = numeric(0), upper = numeric(0))
   }
 
-  # Combine baseline fitted values, post-baseline predictions, and forecast
+  # Generate additional forecast beyond observed data (if h > 0)
+  fc_beyond_result <- if (h > 0) {
+    # Forecast h periods beyond the last observed data point
+    fc_beyond <- mdl |> forecast(h = n_post_baseline + h)
+    # Take only the last h periods (beyond observed data)
+    fc_beyond_hilo <- fabletools::hilo(fc_beyond, 95) |>
+      unpack_hilo(cols = `95%`) |>
+      as_tibble() |>
+      select(.mean, "95%_lower", "95%_upper") |>
+      setNames(c("y", "lower", "upper")) |>
+      tail(h)
+    fc_beyond_hilo
+  } else {
+    tibble(y = numeric(0), lower = numeric(0), upper = numeric(0))
+  }
+
+  # Combine all predictions: leading NAs, pre-baseline, baseline, post-baseline (with PI), forecast beyond (with PI)
   result <- bind_rows(
-    tibble(y = rep(NA, leading_NA)),
-    tibble(y = bl$.mean),
-    tibble(y = post_baseline_predicted),
-    result
+    tibble(y = rep(NA, leading_NA), lower = NA, upper = NA),
+    pre_baseline_result,
+    tibble(y = bl$.mean, lower = NA, upper = NA),
+    post_baseline_result,
+    fc_beyond_result
   ) |>
     mutate_if(is.numeric, round, 1)
 
   # Calculate z-scores using helper function
-  baseline_residuals <- y_baseline[!is.na(y_baseline)] - bl$.mean
+  # Use actual_bs for z-score calculation when there are leading NAs
+  effective_bs <- if (bs == 1 && leading_NA > 0) actual_bs else bs
+  baseline_residuals <- y_baseline_clean[!is.na(y_baseline_clean)] - bl$.mean
   zscores <- calculate_zscores(
     y_full = y_full,
-    baseline_length = baseline_length,
+    bs = effective_bs,
+    be = be,
     baseline_residuals = baseline_residuals,
     mdl = mdl,
     result_length = length(result$y),
-    leading_NA = leading_NA,
-    h = h
+    h = h,
+    df_baseline = df_baseline
   )
 
   list(y = result$y, lower = result$lower, upper = result$upper, zscore = zscores)
@@ -270,7 +346,8 @@ cumForecastN <- function(df_train, df_test, mdl) {
 #' @param y Numeric vector of cumulative observed values (full dataset)
 #' @param h Integer horizon for forecasting
 #' @param t Boolean whether to include trend
-#' @param baseline_length Integer number of data points in baseline period (default: use all data)
+#' @param bs Baseline start index (1-indexed, optional). If NULL, defaults to 1.
+#' @param be Baseline end index (1-indexed, optional). If NULL, defaults to length(y).
 #'
 #' @details
 #' Z-score calculation follows the same semantics as handleForecast():
@@ -278,30 +355,25 @@ cumForecastN <- function(df_train, df_test, mdl) {
 #' standard deviation. See handleForecast() documentation for details.
 #'
 #' @return List with y (fitted + forecast), lower, and upper bounds, and zscore
-handleCumulativeForecast <- function(y, h, t, baseline_length = NULL) {
+handleCumulativeForecast <- function(y, h, t, bs = NULL, be = NULL) {
   y_full <- y
 
-  # If baseline_length is specified, use only that portion for fitting
-  if (!is.null(baseline_length) && baseline_length > 0 && baseline_length < length(y)) {
-    y_baseline <- y[1:baseline_length]
-  } else {
-    y_baseline <- y
-    baseline_length <- length(y)
-  }
+  # Set defaults for baseline start/end if not provided
+  if (is.null(bs)) bs <- 1L
+  if (is.null(be)) be <- length(y)
 
+  # Extract baseline data
+  y_baseline <- y[bs:be]
   n <- length(y_baseline)
 
-  df <- tibble(year = seq.int(1, n), asmr = y_baseline) |>
+  df_baseline <- tibble(year = seq.int(bs, be), asmr = y_baseline) |>
     as_tsibble(index = year)
-
-  # Use ALL input data for training
-  df_train <- df
 
   # Fit model with or without trend
   if (t) {
-    mdl <- df_train |> model(lm = TSLM(asmr ~ trend()))
+    mdl <- df_baseline |> model(lm = TSLM(asmr ~ trend()))
   } else {
-    mdl <- df_train |> model(lm = TSLM(asmr))
+    mdl <- df_baseline |> model(lm = TSLM(asmr))
   }
 
   # Get baseline (fitted values)
@@ -309,52 +381,78 @@ handleCumulativeForecast <- function(y, h, t, baseline_length = NULL) {
     augment() |>
     rename(.mean = .fitted)
 
-  # Generate cumulative forecasts for each horizon
-  result <- tibble()
-  for (h_ in 1:h) {
-    # Create future time periods using fabletools::new_data
-    # Use placeholder value 0 for asmr (not used in predictions, just needed for model.matrix)
-    df_test <- new_data(df_train, n = h_) |>
-      mutate(asmr = 0)
-    result <- rbind(result, cumForecastN(df_train, df_test, mdl))
-  }
+  # Calculate pre-baseline and post-baseline lengths
+  n_pre_baseline <- bs - 1
+  n_post_baseline <- length(y_full) - be
 
-  # Get post-baseline period length
-  n_post_baseline <- if (baseline_length < length(y_full)) {
-    length(y_full) - baseline_length
-  } else {
-    0
-  }
-
-  # Generate baseline predictions for post-baseline period
-  # (what the baseline model predicts, not observed values)
-  post_baseline_predicted <- if (n_post_baseline > 0) {
-    fc_post <- mdl |> forecast(h = n_post_baseline)
-    as_tibble(fc_post) |> pull(.mean)
+  # Generate predictions for pre-baseline period (if any) - no PI
+  pre_baseline_predicted <- if (n_pre_baseline > 0) {
+    first_baseline_idx <- df_baseline$year[1]
+    pre_indices <- (first_baseline_idx - n_pre_baseline):(first_baseline_idx - 1)
+    pre_df <- tibble(year = pre_indices, asmr = y_full[1:n_pre_baseline]) |>
+      as_tsibble(index = year)
+    fc_pre <- mdl |> forecast(new_data = pre_df)
+    as_tibble(fc_pre) |> pull(.mean)
   } else {
     numeric(0)
   }
 
+  # Generate cumulative forecasts for post-baseline period (with PI)
+  post_baseline_result <- if (n_post_baseline > 0) {
+    post_result <- tibble()
+    for (h_ in 1:n_post_baseline) {
+      df_test <- new_data(df_baseline, n = h_) |>
+        mutate(asmr = 0)
+      post_result <- rbind(post_result, cumForecastN(df_baseline, df_test, mdl))
+    }
+    post_result
+  } else {
+    tibble(asmr = numeric(0), lower = numeric(0), upper = numeric(0))
+  }
+
+  # Generate cumulative forecasts for h periods beyond observed data (if h > 0)
+  fc_beyond_result <- if (h > 0) {
+    beyond_result <- tibble()
+    for (h_ in (n_post_baseline + 1):(n_post_baseline + h)) {
+      df_test <- new_data(df_baseline, n = h_) |>
+        mutate(asmr = 0)
+      beyond_result <- rbind(beyond_result, cumForecastN(df_baseline, df_test, mdl))
+    }
+    beyond_result
+  } else {
+    tibble(asmr = numeric(0), lower = numeric(0), upper = numeric(0))
+  }
+
   # Calculate total result length
-  result_length <- nrow(bl) + n_post_baseline + h
+  result_length <- n_pre_baseline + nrow(bl) + n_post_baseline + h
 
   # Calculate z-scores using helper function
-  baseline_residuals <- df_train$asmr - bl$.mean
+  baseline_residuals <- df_baseline$asmr - bl$.mean
   zscores <- calculate_zscores(
     y_full = y_full,
-    baseline_length = baseline_length,
+    bs = bs,
+    be = be,
     baseline_residuals = baseline_residuals,
     mdl = mdl,
     result_length = result_length,
-    leading_NA = 0,  # No leading NAs in cumulative forecast
-    h = h
+    h = h,
+    df_baseline = df_baseline
   )
 
+  # Combine all results with PI for post-baseline and beyond
   # Convert cumulative forecasts back to incremental values
+  post_y <- if (nrow(post_baseline_result) > 0) uncumulate(post_baseline_result$asmr) else numeric(0)
+  post_lower <- if (nrow(post_baseline_result) > 0) uncumulate(post_baseline_result$lower) else numeric(0)
+  post_upper <- if (nrow(post_baseline_result) > 0) uncumulate(post_baseline_result$upper) else numeric(0)
+
+  beyond_y <- if (nrow(fc_beyond_result) > 0) uncumulate(fc_beyond_result$asmr) else numeric(0)
+  beyond_lower <- if (nrow(fc_beyond_result) > 0) uncumulate(fc_beyond_result$lower) else numeric(0)
+  beyond_upper <- if (nrow(fc_beyond_result) > 0) uncumulate(fc_beyond_result$upper) else numeric(0)
+
   list(
-    y = c(bl$.mean, post_baseline_predicted, uncumulate(result$asmr)),
-    lower = c(rep(NA, nrow(bl) + n_post_baseline), uncumulate(result$lower)),
-    upper = c(rep(NA, nrow(bl) + n_post_baseline), uncumulate(result$upper)),
+    y = c(pre_baseline_predicted, bl$.mean, post_y, beyond_y),
+    lower = c(rep(NA, n_pre_baseline + nrow(bl)), post_lower, beyond_lower),
+    upper = c(rep(NA, n_pre_baseline + nrow(bl)), post_upper, beyond_upper),
     zscore = zscores
   )
 }

--- a/tests/test_handlers.r
+++ b/tests/test_handlers.r
@@ -165,9 +165,9 @@ test_that("Z-scores are calculated correctly for mean method", {
   observed_zscores <- result$zscore[1:length(y)]
   expect_true(all(!is.na(observed_zscores)))
 
-  # Z-scores for forecast period should be 0
+  # Z-scores for forecast period should be NA (no observed data)
   forecast_zscores <- tail(result$zscore, h)
-  expect_true(all(forecast_zscores == 0))
+  expect_true(all(is.na(forecast_zscores)))
 })
 
 test_that("Z-scores have mean ~0 and sd ~1 for observed data", {
@@ -187,36 +187,34 @@ test_that("Z-scores have mean ~0 and sd ~1 for observed data", {
 })
 
 # ============================================================================
-# Baseline length feature tests (PR #7)
+# Baseline parameters tests (bs/be for PR, b for legacy backwards compat)
 # ============================================================================
 
-test_that("baseline_length parameter splits data correctly", {
-  # 10 years of data, use first 5 for baseline
+test_that("bs/be parameters split data correctly", {
+  # 10 years of data, use indices 1-5 for baseline (same as legacy b=5)
   y <- c(100, 105, 110, 108, 112, 115, 120, 125, 130, 135)
-  baseline_length <- 5
   h <- 2
   m <- "mean"
   s <- 1
   t <- FALSE
 
-  result <- handleForecast(y, h, m, s, t, baseline_length)
+  result <- handleForecast(y, h, m, s, t, bs = 1, be = 5)
 
   check_forecast_result(result, length(y) + h)
 })
 
-test_that("baseline_length calculates z-scores for all data using baseline stats", {
+test_that("bs/be calculates z-scores for all data using baseline stats", {
   # Create data where post-baseline has higher values
   y_baseline <- c(100, 105, 110, 108, 112) # Mean ~107
   y_post <- c(200, 205, 210) # Much higher
   y <- c(y_baseline, y_post)
 
-  baseline_length <- 5
   h <- 2
   m <- "mean"
   s <- 1
   t <- FALSE
 
-  result <- handleForecast(y, h, m, s, t, baseline_length)
+  result <- handleForecast(y, h, m, s, t, bs = 1, be = 5)
 
   check_forecast_result(result, length(y) + h)
 
@@ -226,14 +224,14 @@ test_that("baseline_length calculates z-scores for all data using baseline stats
   expect_true(all(post_baseline_zscores > 2))
 })
 
-test_that("baseline_length NULL uses all data (backwards compatible)", {
+test_that("bs/be NULL uses all data (backwards compatible)", {
   y <- c(100, 105, 110, 108, 112, 115, 120)
   h <- 3
   m <- "mean"
   s <- 1
   t <- FALSE
 
-  result_with_null <- handleForecast(y, h, m, s, t, baseline_length = NULL)
+  result_with_null <- handleForecast(y, h, m, s, t, bs = NULL, be = NULL)
   result_without <- handleForecast(y, h, m, s, t)
 
   # Results should be identical
@@ -241,42 +239,34 @@ test_that("baseline_length NULL uses all data (backwards compatible)", {
   expect_equal(result_with_null$zscore, result_without$zscore)
 })
 
-test_that("baseline_length validation in integration test", {
-  # This test is now covered by validation tests below
-  # baseline_length >= length(y) should throw an error
-  expect_true(TRUE)
-})
-
-test_that("baseline_length works with different methods", {
+test_that("bs/be works with different methods", {
   y <- c(100, 105, 110, 115, 120, 125, 130, 135)
-  baseline_length <- 5
   h <- 2
   s <- 1
   t <- TRUE
 
   # Test with linear regression
-  result_lr <- handleForecast(y, h, "lin_reg", s, t, baseline_length)
+  result_lr <- handleForecast(y, h, "lin_reg", s, t, bs = 1, be = 5)
   check_forecast_result(result_lr, length(y) + h)
 
   # Test with exponential smoothing
-  result_exp <- handleForecast(y, h, "exp", s, t, baseline_length)
+  result_exp <- handleForecast(y, h, "exp", s, t, bs = 1, be = 5)
   check_forecast_result(result_exp, length(y) + h)
 
   # Test with median
-  result_med <- handleForecast(y, h, "median", s, FALSE, baseline_length)
+  result_med <- handleForecast(y, h, "median", s, FALSE, bs = 1, be = 5)
   check_forecast_result(result_med, length(y) + h)
 })
 
-test_that("baseline_length handles interspersed NAs in post-baseline period", {
+test_that("bs/be handles interspersed NAs in post-baseline period", {
   # Create data with baseline period and post-baseline with interspersed NAs
   y <- c(100, 105, 110, 108, 112, 115, NA, 120, NA, 125)
-  baseline_length <- 5
   h <- 2
   m <- "mean"
   s <- 1
   t <- FALSE
 
-  result <- handleForecast(y, h, m, s, t, baseline_length)
+  result <- handleForecast(y, h, m, s, t, bs = 1, be = 5)
 
   check_forecast_result(result, length(y) + h)
 
@@ -289,9 +279,88 @@ test_that("baseline_length handles interspersed NAs in post-baseline period", {
   expect_true(!is.na(result$zscore[8]))  # Value 120
   expect_true(!is.na(result$zscore[10])) # Value 125
 
-  # Forecast z-scores should still be 0
-  expect_equal(result$zscore[11], 0)
-  expect_equal(result$zscore[12], 0)
+  # Forecast z-scores should be NA (no observed data)
+  expect_true(is.na(result$zscore[11]))
+  expect_true(is.na(result$zscore[12]))
+})
+
+# ============================================================================
+# Pre-baseline z-score tests (new bs/be feature)
+# ============================================================================
+
+test_that("bs > 1 calculates pre-baseline z-scores", {
+  # 10 years of data, baseline is years 3-5
+  y <- c(100, 105, 110, 108, 112, 200, 205, 210, 215, 220)
+  h <- 2
+  m <- "mean"
+  s <- 1
+  t <- FALSE
+
+  result <- handleForecast(y, h, m, s, t, bs = 3, be = 5)
+
+  check_forecast_result(result, length(y) + h)
+
+  # Pre-baseline z-scores (indices 1-2) should be calculated
+  expect_true(!is.na(result$zscore[1]))
+  expect_true(!is.na(result$zscore[2]))
+
+  # Baseline z-scores (indices 3-5) should be calculated
+  expect_true(!is.na(result$zscore[3]))
+  expect_true(!is.na(result$zscore[4]))
+  expect_true(!is.na(result$zscore[5]))
+
+  # Post-baseline z-scores (indices 6-10) should be calculated
+  expect_true(!is.na(result$zscore[6]))
+  expect_true(!is.na(result$zscore[10]))
+
+  # Forecast z-scores should be NA
+  expect_true(is.na(result$zscore[11]))
+  expect_true(is.na(result$zscore[12]))
+})
+
+test_that("Pre-baseline z-scores use model prediction (not baseline mean)", {
+  # Data where pre-baseline is similar to baseline (mean model)
+  # With mean model, pre-baseline prediction = baseline mean
+  y <- c(108, 112, 100, 105, 110, 200, 205, 210)
+  h <- 2
+  m <- "mean"
+  s <- 1
+  t <- FALSE
+
+  result <- handleForecast(y, h, m, s, t, bs = 3, be = 5)
+
+  # Baseline mean is (100+105+110)/3 = 105
+  # Pre-baseline values are 108 and 112
+  # Pre-baseline z-scores should be positive (above mean)
+  expect_true(result$zscore[1] > 0)  # 108 > 105
+  expect_true(result$zscore[2] > 0)  # 112 > 105
+})
+
+test_that("Full example from spec works correctly", {
+  # From spec: 10 years of data, baseline 3-5, forecast 3
+  y <- c(100, 105, 110, 115, 120, 150, 180, 160, 140, 130)
+  h <- 3
+  m <- "mean"
+  s <- 1
+  t <- FALSE
+
+  result <- handleForecast(y, h, m, s, t, bs = 3, be = 5)
+
+  # Result should have 13 values (10 observed + 3 forecast)
+  expect_equal(length(result$y), 13)
+  expect_equal(length(result$zscore), 13)
+
+  # Z-scores for all observed data should be calculated
+  expect_true(all(!is.na(result$zscore[1:10])))
+
+  # Z-scores for forecast should be NA
+  expect_true(all(is.na(result$zscore[11:13])))
+
+  # Confidence intervals only for post-baseline and forecast periods
+  # Pre-baseline (1-2) and baseline (3-5) should have NA for lower/upper
+  expect_true(all(is.na(result$lower[1:5])))
+  # Post-baseline (6-10) and forecast (11-13) should have PI
+  expect_true(all(!is.na(result$lower[6:13])))
 })
 
 # ============================================================================
@@ -325,19 +394,49 @@ test_that("handleCumulativeForecast works without trend", {
   expect_equal(length(result$zscore), length(y) + h)
 })
 
-test_that("handleCumulativeForecast with baseline_length", {
+test_that("handleCumulativeForecast with bs/be", {
   y <- c(1000, 2100, 3300, 4600, 6000, 7500)
-  baseline_length <- 4
   h <- 2
   t <- TRUE
 
-  result <- handleCumulativeForecast(y, h, t, baseline_length)
+  result <- handleCumulativeForecast(y, h, t, bs = 1, be = 4)
 
   expect_equal(length(result$zscore), length(y) + h)
 
   # Post-baseline z-scores should be calculated
   post_baseline_zscores <- result$zscore[5:6]
   expect_true(all(!is.na(post_baseline_zscores)))
+
+  # Forecast z-scores should be NA
+  expect_true(all(is.na(result$zscore[7:8])))
+})
+
+test_that("handleCumulativeForecast with pre-baseline (bs > 1)", {
+  # 8 years of data, baseline is years 3-5 (need at least 3 points)
+  y <- c(1000, 2100, 3300, 4600, 6000, 7500, 9100, 10800)
+  h <- 2
+  t <- TRUE
+
+  result <- handleCumulativeForecast(y, h, t, bs = 3, be = 5)
+
+  expect_equal(length(result$zscore), length(y) + h)
+
+  # Pre-baseline z-scores should be calculated
+  expect_true(!is.na(result$zscore[1]))
+  expect_true(!is.na(result$zscore[2]))
+
+  # Baseline z-scores should be calculated
+  expect_true(!is.na(result$zscore[3]))
+  expect_true(!is.na(result$zscore[4]))
+  expect_true(!is.na(result$zscore[5]))
+
+  # Post-baseline z-scores should be calculated
+  expect_true(!is.na(result$zscore[6]))
+  expect_true(!is.na(result$zscore[7]))
+  expect_true(!is.na(result$zscore[8]))
+
+  # Forecast z-scores should be NA
+  expect_true(all(is.na(result$zscore[9:10])))
 })
 
 # ============================================================================

--- a/tests/test_integration.r
+++ b/tests/test_integration.r
@@ -264,14 +264,14 @@ test_that("Baseline length parameter 'b' works for standard forecast", {
   expect_equal(length(body$zscore), 12)
 
   # Z-scores should exist for all observed data (indices 1-10)
-  expect_true(!is.na(body$zscore[[1]]))
-  expect_true(!is.na(body$zscore[[5]])) # Last baseline point
-  expect_true(!is.na(body$zscore[[6]])) # First post-baseline point
-  expect_true(!is.na(body$zscore[[10]])) # Last observed point
+  expect_true(!is.null(body$zscore[[1]]))
+  expect_true(!is.null(body$zscore[[5]])) # Last baseline point
+  expect_true(!is.null(body$zscore[[6]])) # First post-baseline point
+  expect_true(!is.null(body$zscore[[10]])) # Last observed point
 
-  # Forecast z-scores should be 0
-  expect_equal(body$zscore[[11]], 0)
-  expect_equal(body$zscore[[12]], 0)
+  # Forecast z-scores should be null (NA in R -> null in JSON)
+  expect_null(body$zscore[[11]])
+  expect_null(body$zscore[[12]])
 })
 
 test_that("Baseline length parameter 'b' works for cumulative forecast", {
@@ -291,12 +291,12 @@ test_that("Baseline length parameter 'b' works for cumulative forecast", {
   expect_equal(length(body$zscore), 8)
 
   # Z-scores should exist for all observed data
-  expect_true(!is.na(body$zscore[[1]]))
-  expect_true(!is.na(body$zscore[[6]])) # Last observed point
+  expect_true(!is.null(body$zscore[[1]]))
+  expect_true(!is.null(body$zscore[[6]])) # Last observed point
 
-  # Forecast z-scores should be 0
-  expect_equal(body$zscore[[7]], 0)
-  expect_equal(body$zscore[[8]], 0)
+  # Forecast z-scores should be null (NA in R -> null in JSON)
+  expect_null(body$zscore[[7]])
+  expect_null(body$zscore[[8]])
 })
 
 test_that("Baseline length 'b' with different methods works", {

--- a/tests/test_validation.r
+++ b/tests/test_validation.r
@@ -111,6 +111,125 @@ test_that("validate_request rejects invalid method", {
   expect_match(result$message, "naive, mean, median, lin_reg, exp")
 })
 
+# ============================================================================
+# bs/be parameter validation tests
+# ============================================================================
+
+test_that("validate_request accepts valid bs/be parameters", {
+  query <- list(
+    y = "10,20,30,40,50,60,70,80",
+    h = "2",
+    s = "1",
+    m = "mean",
+    bs = "3",
+    be = "5"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_true(result$valid)
+})
+
+test_that("validate_request rejects bs without be", {
+  query <- list(
+    y = "10,20,30,40,50",
+    h = "2",
+    s = "1",
+    m = "mean",
+    bs = "1"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_false(result$valid)
+  expect_equal(result$status, 400)
+  expect_match(result$message, "must both be provided together")
+})
+
+test_that("validate_request rejects be without bs", {
+  query <- list(
+    y = "10,20,30,40,50",
+    h = "2",
+    s = "1",
+    m = "mean",
+    be = "3"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_false(result$valid)
+  expect_equal(result$status, 400)
+  expect_match(result$message, "must both be provided together")
+})
+
+test_that("validate_request rejects bs < 1", {
+  query <- list(
+    y = "10,20,30,40,50",
+    h = "2",
+    s = "1",
+    m = "mean",
+    bs = "0",
+    be = "3"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_false(result$valid)
+  expect_equal(result$status, 400)
+  expect_match(result$message, "bs.*>= 1")
+})
+
+test_that("validate_request rejects be <= bs", {
+  query <- list(
+    y = "10,20,30,40,50",
+    h = "2",
+    s = "1",
+    m = "mean",
+    bs = "3",
+    be = "3"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_false(result$valid)
+  expect_equal(result$status, 400)
+  expect_match(result$message, "be.*> 'bs'")
+})
+
+test_that("validate_request rejects be > length(y)", {
+  query <- list(
+    y = "10,20,30,40,50",
+    h = "2",
+    s = "1",
+    m = "mean",
+    bs = "1",
+    be = "10"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_false(result$valid)
+  expect_equal(result$status, 400)
+  expect_match(result$message, "be.*<= data length")
+})
+
+test_that("validate_request rejects bs/be with insufficient non-NA values", {
+  query <- list(
+    y = "10,NA,NA,40,50",
+    h = "2",
+    s = "1",
+    m = "mean",
+    bs = "1",
+    be = "3"
+  )
+
+  result <- validate_request(query, "/")
+
+  expect_false(result$valid)
+  expect_equal(result$status, 400)
+  expect_match(result$message, "At least 3 non-NA values")
+})
+
 test_that("generate_cache_key creates consistent keys", {
   query1 <- list(y = "10,20,30", h = "5", s = "1", m = "mean")
   query2 <- list(m = "mean", s = "1", h = "5", y = "10,20,30") # Different order


### PR DESCRIPTION
## Summary
- Add `bs` (baseline start) and `be` (baseline end) parameters (1-indexed) for flexible baseline range specification
- Post-baseline values automatically receive prediction intervals when bs/be are provided
- Maintain backwards compatibility with legacy `b` parameter
- Change forecast z-scores from 0 to NA (null in JSON)
- Add CORS headers for local development

Closes #202

## Test plan
- [x] Unit tests pass (206 tests)
- [x] Integration tests pass (22 tests)
- [x] Validation tests for bs/be parameters
- [x] Backwards compatibility with `b` parameter verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)