### PR TITLE
fix: remove duplicate CORS headers

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,11 @@
       "Bash(do)",
       "Bash(if curl -s http://localhost:5000/health)",
       "Bash(then)",
-      "Bash(timeout 10 Rscript:*)"
+      "Bash(timeout 10 Rscript:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:stats.mortality.watch)",
+      "Bash(ls:*)",
+      "Bash(./deploy.sh:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/serve.r
+++ b/src/serve.r
@@ -344,7 +344,6 @@ send_error <- function(server, request, status, message) {
   response$body <- jsonlite::toJSON(list(error = message, status = status), auto_unbox = TRUE)
   response$status <- status
   response$type <- "json"
-  response$set_header("Access-Control-Allow-Origin", "*")
   return(response)
 }
 
@@ -377,7 +376,6 @@ app$on("request", function(server, request, ...) {
     ), auto_unbox = TRUE)
     response$status <- 200L
     response$type <- "json"
-    response$set_header("Access-Control-Allow-Origin", "*")
 
     log_message("INFO", "Health check", list(status = "ok"))
     return(response)
@@ -424,7 +422,6 @@ app$on("request", function(server, request, ...) {
     response$status <- 200L
     response$type <- "json"
     response$set_header("X-Cache", "HIT")
-    response$set_header("Access-Control-Allow-Origin", "*")
     return(response)
   }
 
@@ -496,7 +493,6 @@ app$on("request", function(server, request, ...) {
   response$status <- 200L
   response$type <- "json"
   response$set_header("X-Cache", "MISS")
-  response$set_header("Access-Control-Allow-Origin", "*")
 
   # Log completion
   duration_ms <- round(as.numeric(difftime(Sys.time(), start_time, units = "secs")) * 1000, 2)


### PR DESCRIPTION
## Summary
- nginx-cors plugin handles CORS headers
- R server was also adding `Access-Control-Allow-Origin: *`
- This resulted in duplicate `*, *` which browsers reject

## Test plan
- [ ] Test CORS requests from mortality.watch frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)